### PR TITLE
fix: Use the right parameter in the call to the RabbitMQQueue constructor

### DIFF
--- a/src/RabbitMQQueueWithDeclare.php
+++ b/src/RabbitMQQueueWithDeclare.php
@@ -10,7 +10,7 @@ class RabbitMQQueueWithDeclare extends RabbitMQQueue
 {
     public function __construct(AbstractConnection $connection, string $default, array $options = [])
     {
-        parent::__construct($connection, $default, $options);
+        parent::__construct($connection, $default, false, $options);
 
         $this->declareQueue($this->getQueue(), true, false, $this->getQueueArguments($this->getQueue()));
 


### PR DESCRIPTION
This PR is in order to solve the following error:
```
VladimirYuldashev\LaravelQueueRabbitMQ\Queue\RabbitMQQueue: :__construct(): Argument #3 ($dispatchAfterCommit) must be of type bool, array given, called in /opt/app/vendor/softonic/laravel-queue-job/src/RabbitMQQueueWithDeclare.php on line 13
```
